### PR TITLE
Fixes #23, don't clear root authkeys on virtualbox, which is the base

### DIFF
--- a/image-templates/aws-hvm.json
+++ b/image-templates/aws-hvm.json
@@ -48,7 +48,8 @@
         "scripts/aws/cloud-init-enable.sh",
         "scripts/aws/sriov.sh",
         "scripts/common/nic.sh",
-        "scripts/common/cleanup.sh"
+        "scripts/common/cleanup.sh",
+        "scripts/common/clear_root_authkeys.sh"
       ]
     },
     {

--- a/image-templates/aws-paravirt.json
+++ b/image-templates/aws-paravirt.json
@@ -47,7 +47,8 @@
         "scripts/aws/aws-modules.sh",
         "scripts/aws/cloud-init-enable.sh",
         "scripts/common/nic.sh",
-        "scripts/common/cleanup.sh"
+        "scripts/common/cleanup.sh",
+        "scripts/common/clear_root_authkeys.sh"
       ]
     },
     {

--- a/image-templates/vagrant.json
+++ b/image-templates/vagrant.json
@@ -44,7 +44,8 @@
         "scripts/vagrant/vbox-guest-additions.sh",
         "scripts/vagrant/vagrant-user.sh",
         "scripts/common/nic.sh",
-        "scripts/common/cleanup.sh"
+        "scripts/common/cleanup.sh",
+        "scripts/common/clear_root_authkeys.sh"
       ]
     },
     {

--- a/image-templates/virtualbox.json
+++ b/image-templates/virtualbox.json
@@ -69,7 +69,8 @@
         "scripts/virtualbox/packages.sh",
         "scripts/virtualbox/serial.sh",
         "scripts/virtualbox/sshd.sh",
-        "scripts/common/nic.sh"
+        "scripts/common/nic.sh",
+        "scripts/common/cleanup.sh"
       ]
     },
     {

--- a/scripts/common/cleanup.sh
+++ b/scripts/common/cleanup.sh
@@ -9,6 +9,3 @@ yum clean all
 if [ -f /tmp/VBoxGuestAdditions.iso ]; then
     rm /tmp/VBoxGuestAdditions.iso
 fi
-
-# Delete builder key.
-echo > /root/.ssh/authorized_keys

--- a/scripts/common/clear_root_authkeys.sh
+++ b/scripts/common/clear_root_authkeys.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -x
+#
+# This script should be included by every build except virtualbox
+
+# Delete builder key.
+echo > /root/.ssh/authorized_keys


### PR DESCRIPTION
The virtualbox profile was not running cleanup.sh, which was causing a test failure in tests/spec/vboxguestadditions_spec.rb which expects /tmp/VBoxGuestAdditions.iso to have been removed.

Disabling this test allowed me to make progress, but was clearly not the correct solution.

Running cleanup.sh in the virtualbox profile, however, caused the SSH connection to fail when building other profiles, because the /root/.ssh/authorized_keys file had been removed.

I've separated these two actions, and have cleanup.sh running on all profiles, and clearing root authkeys on all profiles but virtualbox.

I've tested this a couple of times and it seems to work fine!
