### PR TITLE
Update nscd.sh

### DIFF
--- a/scripts/virtualbox/nscd.sh
+++ b/scripts/virtualbox/nscd.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 
 # ensure nscd is enabled for boot
 if [ "${os_version::1}" == "7" ]; then


### PR DESCRIPTION
Throw it a bang for the hashbang.

I mean, it's not going to error out just for that as we're essentially doing an 'sh script.sh' and not just handing it control.  So it's interpreting it already, and that's cool.  But let's be complete.

(Being Complete is why I left the 'systemctl' bit in there, even though we know 'chkconfig nscd on' works for RHEL7 as well as EVERY RHEL EVER MADE (grr RedHat and your pointless changes) because, you know, completeness)